### PR TITLE
[IP-4323] - Add tinymce opening class to presentation button

### DIFF
--- a/src/core/src/main/js/ui/ColorButton.js
+++ b/src/core/src/main/js/ui/ColorButton.js
@@ -37,7 +37,7 @@ define(
        */
       init: function (settings) {
         this._super(settings);
-        this.classes.add('colorbutton');
+        this.classes.add('colorbutton').add('open');
       },
 
       /**


### PR DESCRIPTION
## What:
Add tinymce opening class to "presentation" and actual button parent element.

## Why:
Currently the "presentation" button does not activate the dropdown and feels to be broken.

### JIRA:
https://bislrdev.atlassian.net/browse/IP-4323